### PR TITLE
Upgrade knex to ^2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:12-alpine
+FROM node:18-alpine
 
 WORKDIR /usr/src/app

--- a/lib/unexpected-knex.js
+++ b/lib/unexpected-knex.js
@@ -1,8 +1,8 @@
 const util = require('util');
 const Knex = require('knex');
 const proxyquire = require('proxyquire');
-const QueryBuilder = require('knex/lib/query/builder');
-const knexMigrationListResolver = require('knex/lib/migrate/migration-list-resolver');
+const QueryBuilder = require('knex/lib/query/querybuilder');
+const knexMigrationListResolver = require('knex/lib/migrations/migrate/migration-list-resolver');
 
 let unexpectedKnexMigratorFilename;
 const getUnexpectedKnexMigratorFilenames = function (sources) {
@@ -25,7 +25,7 @@ const unexpectedKnexMigrationListResolver = Object.assign(
   },
 );
 
-const UnexpectedKnexMigrator = proxyquire('knex/lib/migrate/Migrator', {
+const UnexpectedKnexMigrator = proxyquire('knex/lib/migrations/migrate/Migrator', {
   './migration-list-resolver': unexpectedKnexMigrationListResolver,
 }).Migrator;
 

--- a/lib/unexpected-knex.js
+++ b/lib/unexpected-knex.js
@@ -25,9 +25,12 @@ const unexpectedKnexMigrationListResolver = Object.assign(
   },
 );
 
-const UnexpectedKnexMigrator = proxyquire('knex/lib/migrations/migrate/Migrator', {
-  './migration-list-resolver': unexpectedKnexMigrationListResolver,
-}).Migrator;
+const UnexpectedKnexMigrator = proxyquire(
+  'knex/lib/migrations/migrate/Migrator',
+  {
+    './migration-list-resolver': unexpectedKnexMigrationListResolver,
+  },
+).Migrator;
 
 function MigrationTest(knex, expect) {
   this.knex = knex;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Joel Mukuthu <joelmukuthu@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "knex": "^0.16.0",
+    "knex": "^0.95.0 || ^1 || ^2",
     "unexpected": "^10.27.0 || ^11.0.0 || ^12.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-n": "^16.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
-    "knex": "^0.21.0",
+    "knex": "^2.5.1",
     "mocha": "^10.2.0",
     "mock-fs": "^5.2.0",
     "nyc": "^15.1.0",

--- a/test/unexpected-knex.spec.js
+++ b/test/unexpected-knex.spec.js
@@ -10,7 +10,7 @@ const assertErrorOuput = process.env.ASSERT_ERROR_OUTPUT !== 'false';
 
 // This file is `require`d lazily by Knex's migrator, so we have to require it
 // here so that it's cached by Node.js before we go on to mock out `require`.
-require('knex/lib/util/import-file.js');
+require('knex/lib/migrations/util/import-file.js');
 // Knex `require`s migrations lazily and in the process tries to figure out if
 // it should use `import` or `require`. The following hacks make it bypass those
 // checks and default to using `require`.

--- a/test/unexpected-knex.spec.js
+++ b/test/unexpected-knex.spec.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const Knex = require('knex');
-const QueryBuilder = require('knex/lib/query/builder');
+const QueryBuilder = require('knex/lib/query/querybuilder');
 const unexpected = require('unexpected');
 const mockFs = require('mock-fs');
 const unexpectedRequire = require('unexpected-require');


### PR DESCRIPTION
This PR:
- Upgrades node runtime to 18.17
- Updates the `knex` dependency to ^2.5.1
  - This is a BREAKING CHANGE matching the breaking change version from knex